### PR TITLE
Format list_for_each_safe correctly

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -18,6 +18,7 @@ ForEachMacros:
   - Q_FOREACH
   - BOOST_FOREACH
   - list_for_each
+  - list_for_each_safe
   - list_for_each_entry
   - list_for_each_entry_safe
   - hlist_for_each_entry


### PR DESCRIPTION
This macro is missed by the .clang-format